### PR TITLE
[FIX] Removing no longer working dnf command

### DIFF
--- a/fedora_update.bash
+++ b/fedora_update.bash
@@ -47,9 +47,7 @@ update() {
 }
 cleanuptime() {
 
-        sudo dnf autoremove;
-
-        sudo dnf autoclean -y;
+        sudo dnf autoremove -y;
 }
 bounce() {
         echo


### PR DESCRIPTION
error get : "No such command: autoclean. Please use /usr/bin/dnf --help"